### PR TITLE
Add climbing activity type

### DIFF
--- a/tapiriik/services/Endomondo/endomondo.py
+++ b/tapiriik/services/Endomondo/endomondo.py
@@ -53,6 +53,7 @@ class EndomondoService(ServiceBase):
         "treadmill running": ActivityType.Running,
         "snowshoeing": ActivityType.Walking,
         "wheelchair": ActivityType.Wheelchair,
+        "climbing": ActivityType.Climbing,
         "treadmill walking": ActivityType.Walking
     }
 
@@ -70,6 +71,7 @@ class EndomondoService(ServiceBase):
         "other": ActivityType.Other,
         "snowshoeing": ActivityType.Walking,
         "wheelchair": ActivityType.Wheelchair,
+        "climbing" : Activititype.Climbing
     }
 
     SupportedActivities = list(_activityMappings.values())

--- a/tapiriik/services/GarminConnect/garminconnect.py
+++ b/tapiriik/services/GarminConnect/garminconnect.py
@@ -54,6 +54,7 @@ class GarminConnectService(ServiceBase):
                                 "rowing": ActivityType.Rowing,
                                 "elliptical": ActivityType.Elliptical,
                                 "fitness_equipment": ActivityType.Gym,
+                                "mountaineering": ActivityTYpe.Climbing,
                                 "all": ActivityType.Other  # everything will eventually resolve to this
     }
 
@@ -70,6 +71,7 @@ class GarminConnectService(ServiceBase):
                                 "rowing": ActivityType.Rowing,
                                 "elliptical": ActivityType.Elliptical,
                                 "fitness_equipment": ActivityType.Gym,
+                                "mountaineering": ActivityType.Climbing,
                                 "other": ActivityType.Other  # I guess? (vs. "all" that is)
     }
 

--- a/tapiriik/services/interchange.py
+++ b/tapiriik/services/interchange.py
@@ -20,6 +20,7 @@ class ActivityType:  # taken from RK API docs. The text values have no meaning e
     Rowing = "Rowing"
     Elliptical = "Elliptical"
     Gym = "Gym"
+    Climbing = "Climbing"
     Other = "Other"
 
     def List():


### PR DESCRIPTION
Endomondo supports "Climbing" and Garmin Connect has "Mountaineering",
link the two.

This tries to follow 3ada45e4 ("Gym activity type.").

This is completely untested, so feel free to consider this a feature request rather than a pull request.
