### PR TITLE
Use platform independent temporary directory in GarminConnect service

### DIFF
--- a/tapiriik/services/GarminConnect/garminconnect.py
+++ b/tapiriik/services/GarminConnect/garminconnect.py
@@ -22,6 +22,7 @@ import time
 import json
 import re
 import random
+import tempfile
 from urllib.parse import urlencode
 logger = logging.getLogger(__name__)
 
@@ -115,7 +116,7 @@ class GarminConnectService(ServiceBase):
             cachedb.gc_type_hierarchy.insert({"Hierarchy": rawHierarchy})
         else:
             self._activityHierarchy = json.loads(cachedHierarchy["Hierarchy"])["dictionary"]
-        rate_lock_path = "/tmp/gc_rate.%s.lock" % HTTP_SOURCE_ADDR
+        rate_lock_path = tempfile.gettempdir() + "/gc_rate.%s.lock" % HTTP_SOURCE_ADDR
         # Ensure the rate lock file exists (...the easy way)
         open(rate_lock_path, "a").close()
         self._rate_lock = open(rate_lock_path, "r+")


### PR DESCRIPTION
I ran into a little issue trying to get tapiriik to run on my Windows machine, caused by the hardcoded temp path in the Garmin Connect service. 

I have resolved this by implementing a platform independent way to determine the current tempfile folder based on http://stackoverflow.com/questions/847850/cross-platform-way-of-getting-temp-directory-in-python
