### PR TITLE
Fixing some references that were incorrect with the move of the payments module

### DIFF
--- a/tapiriik/auth/__init__.py
+++ b/tapiriik/auth/__init__.py
@@ -1,4 +1,4 @@
-from .payment import *
+from tapiriik.payments import *
 from .totp import *
 from tapiriik.database import db
 from tapiriik.sync import Sync

--- a/tapiriik/payments/__init__.py
+++ b/tapiriik/payments/__init__.py
@@ -1,1 +1,1 @@
-from payment import Payments
+from .payments import Payments


### PR DESCRIPTION
The recent move of the payments module caused the server process to throw errors about not being able to find modules because they were moved and renamed. This fixes up the problems I found and gets the server working again.
