### PR TITLE
fix rwgps to handle json response

### DIFF
--- a/tapiriik/services/RideWithGPS/rwgps.py
+++ b/tapiriik/services/RideWithGPS/rwgps.py
@@ -109,7 +109,7 @@ class RideWithGPSService(ServiceBase):
         params = self._add_auth_params({}, record=serviceRecord)
 
         res = requests.get("http://ridewithgps.com/users/{}/trips.json".format(serviceRecord.ExternalID), params=params)
-        res = res.json()
+        res = res.json().get('results', [])
         if res == []:
             return [], [] # No activities
         for act in res:


### PR DESCRIPTION
I don't know if this has changed recently, but RideWithGPS's response back from http://ridewithgps.com/users/{}/trips.json returns a dictionary that looks like

```
{
    'results': [],
    'results_counts': <int>
}
```

This fix handles this response
