### PR TITLE
Implement pause algorithm when downloading Strava activity

### DIFF
--- a/tapiriik/services/Strava/strava.py
+++ b/tapiriik/services/Strava/strava.py
@@ -224,14 +224,20 @@ class StravaService(ServiceBase):
                     waypoint.Location = Location(None, None, None)
                 waypoint.Location.Altitude = float(ridedata["altitude"][idx])
 
+            # When pausing, Strava sends this format:
+            # idx = 100 ; time = 1000; moving = true
+            # idx = 101 ; time = 1001; moving = true  => convert to Pause
+            # idx = 102 ; time = 2001; moving = false => convert to Resume: (2001-1001) seconds pause
+            # idx = 103 ; time = 2002; moving = true
+
             if idx == 0:
                 waypoint.Type = WaypointType.Start
             elif idx == waypointCt - 2:
                 waypoint.Type = WaypointType.End
-            elif ridedata["moving"][idx] and inPause:
+            elif idx < waypointCt - 2 and ridedata["moving"][idx+1] and inPause:
                 waypoint.Type = WaypointType.Resume
                 inPause = False
-            elif not ridedata["moving"][idx] and not inPause:
+            elif idx < waypointCt - 2 and not ridedata["moving"][idx+1] and not inPause:
                 waypoint.Type = WaypointType.Pause
                 inPause = True
 


### PR DESCRIPTION
After comparing some activities recorded in Runkeeper and sent to Strava and viceversa, the conclusion was that the problem was in the transformacion from Strava json response to the activity.

I've searched the algorithm and it wasn't using the "moving" True/False info from the json.

I'm new to python and git, so if something is wrong, let me know
