### PR TITLE
add TomTom GPS Sport Watch device IDs

### DIFF
--- a/tapiriik/services/devices.py
+++ b/tapiriik/services/devices.py
@@ -119,3 +119,6 @@ DeviceIdentifier.AddIdentifierGroup(*_garminIdentifier("Training Center", 20119)
 
 DeviceIdentifier.AddIdentifierGroup(*_garminIdentifier("Forerunner 620", 1623))
 
+# TomTom MySports Connect appears to produce these IDs for all of their
+# models of GPS watches (Runner, MultiSport, and Cardio versions of the same).
+DeviceIdentifier.AddIdentifierGroup(TCXDeviceIdentifier("TomTom GPS Sport Watch", 0), FITDeviceIdentifier(71, 0))


### PR DESCRIPTION
As long as I'm adding pull requests, might as well get Tapiriik to preserve a record of what device I'm using :-)

The Windows version of TomTom MySports Connect appears to produce these same IDs for all of their models of GPS watches (Runner and MultiSport confirmed, probably for the Cardio versions of the same too).

This usage is, frankly, dumb and lazy because the individual models have `uint16` numeric IDs which [could easily be exported](https://github.com/dlenski/ttwatch/commit/1600dce). Also, on my watch the FIT UnitID value is 74565 (`0x12345`), so that's probably bogus too.