### PR TITLE
Fix broken vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "chef/ubuntu-13.10"
+  config.vm.box = "chef/ubuntu-14.04"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,8 +11,8 @@ pip3 install --upgrade pip
 pip install -r /vagrant/requirements.txt
 
 # Fix the default python instance
-sudo rm `which python`
-sudo ln -s /usr/bin/python3.3 /usr/bin/python
+update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
+update-alternatives --install /usr/bin/python python /usr/bin/python3.4 2
 
 # Put in a default local_settings.py
 cp /vagrant/tapiriik/local_settings.py.example /vagrant/tapiriik/local_settings.py


### PR DESCRIPTION
These changes update the base vagrant box to 14.04, since using 13.10 doesn't seem to really work anymore (the apt repositories don't seem to exist anymore, so it was either changing the sources.list to point old-release.ubuntu.com or updating to the latest LTS).

I also made a minor change to the bootstrap script since 14.04 has python 3.4 instead of 3.3

Note that i haven't done any extensive testing, but spinning up the sync worker and the web server both seems to work.