### PR TITLE
vagrant: don't overwrite existing local_settings.py during (re)provision

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,8 +14,10 @@ pip install -r /vagrant/requirements.txt
 update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
 update-alternatives --install /usr/bin/python python /usr/bin/python3.4 2
 
-# Put in a default local_settings.py
-cp /vagrant/tapiriik/local_settings.py.example /vagrant/tapiriik/local_settings.py
+# Put in a default local_settings.py (if one doesn't exist)
+if [ ! -f /vagrant/tapiriik/local_settings.py ]; then
+    cp /vagrant/tapiriik/local_settings.py.example /vagrant/tapiriik/local_settings.py
+    # Generate credential storage keys
+    python /vagrant/credentialstore_keygen.py >> /vagrant/tapiriik/local_settings.py
+fi
 
-# Generate credential storage keys
-python /vagrant/credentialstore_keygen.py >> /vagrant/tapiriik/local_settings.py


### PR DESCRIPTION
I got bit by this when running 'vagrant provision' a second time to
update some dependencies and it wiped out my customized
local_settings.py