### PR TITLE
Smashrun: fix exhaustive check

### DIFF
--- a/tapiriik/services/Smashrun/smashrun.py
+++ b/tapiriik/services/Smashrun/smashrun.py
@@ -79,7 +79,7 @@ class SmashrunService(ServiceBase):
 
         for i, act in enumerate(client.get_activities()):
             # bail out early after some arbitrary number if not exhaustive
-            if exhaustive and i > 20:
+            if not exhaustive and i > 20:
                 break
             activity = UploadedActivity()
             activity.StartTime = dateutil.parser.parse(act['startDateTimeLocal'])

--- a/tapiriik/services/Smashrun/smashrun.py
+++ b/tapiriik/services/Smashrun/smashrun.py
@@ -226,7 +226,6 @@ class SmashrunService(ServiceBase):
                        'endDistance': lap.Waypoints[-1].Distance / 1000}
             data['laps'].append(lapinfo)
             for wp in lap.Waypoints:
-                logger.info(wp)
                 if hasDistance:
                     recordings['distance'].append(wp.Distance / 1000)
                 if hasTimestamp:


### PR DESCRIPTION
There was a missing 'not' that resulted in the smashrun service only fetching the first 20 activities if exhaustive was True, and *all* activities if exhaustive was False.

This fixes it and also removes a noisy log message during activity upload that i accidentally left in.