### PR TITLE
smashrun: cache auth token

### DIFF
--- a/tapiriik/services/sessioncache.py
+++ b/tapiriik/services/sessioncache.py
@@ -15,7 +15,7 @@ class SessionCache:
             try:
                 res = pickle.loads(res)
             except pickle.UnpicklingError:
-                redis.delete(self._cacheKey % pk)
+                self.Delete(pk)
                 res = None
             else:
                 if self._autorefresh or freshen:
@@ -25,3 +25,6 @@ class SessionCache:
     def Set(self, pk, value, lifetime=None):
         lifetime = lifetime or self._lifetime
         redis.setex(self._cacheKey % pk, pickle.dumps(value), lifetime)
+
+    def Delete(self, pk):
+        redis.delete(self._cacheKey % pk)

--- a/tapiriik/services/sessioncache.py
+++ b/tapiriik/services/sessioncache.py
@@ -3,24 +3,24 @@ from tapiriik.database import redis
 import pickle
 
 class SessionCache:
-	def __init__(self, scope, lifetime, freshen_on_get=False):
-		self._lifetime = lifetime
-		self._autorefresh = freshen_on_get
-		self._scope = scope
-		self._cacheKey = "sessioncache:%s:%s" % (self._scope, "%s")
+    def __init__(self, scope, lifetime, freshen_on_get=False):
+        self._lifetime = lifetime
+        self._autorefresh = freshen_on_get
+        self._scope = scope
+        self._cacheKey = "sessioncache:%s:%s" % (self._scope, "%s")
 
-	def Get(self, pk, freshen=False):
-		res = redis.get(self._cacheKey % pk)
-		if res:
-			try:
-				res = pickle.loads(res)
-			except pickle.UnpicklingError:
-				redis.delete(self._cacheKey % pk)
-				res = None
-			else:
-				if self._autorefresh or freshen:
-					redis.expire(self._cacheKey % pk, self._lifetime)
-			return res
+    def Get(self, pk, freshen=False):
+        res = redis.get(self._cacheKey % pk)
+        if res:
+            try:
+                res = pickle.loads(res)
+            except pickle.UnpicklingError:
+                redis.delete(self._cacheKey % pk)
+                res = None
+            else:
+                if self._autorefresh or freshen:
+                    redis.expire(self._cacheKey % pk, self._lifetime)
+            return res
 
-	def Set(self, pk, value):
-		redis.setex(self._cacheKey % pk, pickle.dumps(value), self._lifetime)
+    def Set(self, pk, value):
+        redis.setex(self._cacheKey % pk, pickle.dumps(value), self._lifetime)

--- a/tapiriik/services/sessioncache.py
+++ b/tapiriik/services/sessioncache.py
@@ -22,5 +22,6 @@ class SessionCache:
                     redis.expire(self._cacheKey % pk, self._lifetime)
             return res
 
-    def Set(self, pk, value):
-        redis.setex(self._cacheKey % pk, pickle.dumps(value), self._lifetime)
+    def Set(self, pk, value, lifetime=None):
+        lifetime = lifetime or self._lifetime
+        redis.setex(self._cacheKey % pk, pickle.dumps(value), lifetime)


### PR DESCRIPTION
Instead of refreshing the token on every sync (which is pretty wasteful), we now cache the token in redis, with an expiry that is slightly less than the `expires_in` field of the auth token (12 weeks).

It also now handles token expiry and revocation better and if all else fails will request user intervention.