### PR TITLE
 Addressing issue cpfair/tapiriik#117.

### DIFF
--- a/tapiriik/services/Endomondo/endomondo.py
+++ b/tapiriik/services/Endomondo/endomondo.py
@@ -238,6 +238,8 @@ class EndomondoService(ServiceBase):
 
         activity.GPS = False
 
+        prevLon = 0.0
+        prevLat = 0.0
         for pt in resp["points"]:
             wp = Waypoint()
             if "time" not in pt:
@@ -252,6 +254,19 @@ class EndomondoService(ServiceBase):
                 if "lat" in pt and "lng" in pt:
                     wp.Location.Latitude = pt["lat"]
                     wp.Location.Longitude = pt["lng"]
+                    if (wp.Location.Latitude == prevLat and wp.Location.Longitude == prevLon):
+                        # we have seen the point with the same coordinates
+                        # before. This causes other services (e.g Strava) to
+                        # interpret this as if we were standing for a while,
+                        # which causes us having wrong activity time when
+                        # importing. We discard this entry to keep only unique
+                        # ones to avoid this. This is still a hack :( However,
+                        # I don't know if this will handle the situation when
+                        # we are actually standing for some time in one place
+                        # well...
+                        continue;
+                    prevLat = wp.Location.Latitude;
+                    prevLon = wp.Location.Longitude;
                     activity.GPS = True
                 if "alt" in pt:
                     wp.Location.Altitude = pt["alt"]


### PR DESCRIPTION
discard waypoints with exactly the same gps positions. This confuses Strava import. Addressing issue cpfair/tapiriik#117. May cause issues with workouts that actually include a long period of staying in one place