### PR TITLE
Add new GC activity type Rock Climbing

### DIFF
--- a/tapiriik/services/GarminConnect/garminconnect.py
+++ b/tapiriik/services/GarminConnect/garminconnect.py
@@ -56,6 +56,7 @@ class GarminConnectService(ServiceBase):
                                 "rowing": ActivityType.Rowing,
                                 "elliptical": ActivityType.Elliptical,
                                 "fitness_equipment": ActivityType.Gym,
+                                "rock_climbing": ActivityType.Climbing,
                                 "mountaineering": ActivityType.Climbing,
                                 "all": ActivityType.Other,  # everything will eventually resolve to this
                                 "multi_sport": ActivityType.Other # Most useless type? You decide!
@@ -74,7 +75,7 @@ class GarminConnectService(ServiceBase):
                                 "rowing": ActivityType.Rowing,
                                 "elliptical": ActivityType.Elliptical,
                                 "fitness_equipment": ActivityType.Gym,
-                                "mountaineering": ActivityType.Climbing,
+                                "rock_climbing": ActivityType.Climbing,
                                 "other": ActivityType.Other  # I guess? (vs. "all" that is)
     }
 


### PR DESCRIPTION
Garmin Connect recently added a few new activity types, including
"Other: Rock Climbing". Add this as a Climbing type activity in tapiriik
and use Rock Climbing instead of Mountaineering in the reverse mapping
for Climbing.

Other new activity types in GC include RC/Drone and Wingsuit flying, I
guess there is no reason to add those unless someone asks for it.

This is change is completely untested.