### PR TITLE
endomondo.py: orienteering should be mapped to running, not walking

### DIFF
--- a/tapiriik/services/Endomondo/endomondo.py
+++ b/tapiriik/services/Endomondo/endomondo.py
@@ -46,7 +46,7 @@ class EndomondoService(ServiceBase):
         "rowing": ActivityType.Rowing,
         "fitness walking": ActivityType.Walking,
         "hiking": ActivityType.Hiking,
-        "orienteering": ActivityType.Walking,
+        "orienteering": ActivityType.Running,
         "walking": ActivityType.Walking,
         "swimming": ActivityType.Swimming,
         "other": ActivityType.Other,


### PR DESCRIPTION
I believe that Running should be used instead of Walking, since the purpose of orienteering is [(according to wikipedia)](https://en.wikipedia.org/wiki/Orienteering) to:

> test the navigational skill, concentration, and running ability of the competitors.

(My main issue with orienteering being treated as walking is that Strava ignores segments for orienteering activities when synced.)