### PR TITLE
Use gauthHost parameter in Garmin SSO Login

### DIFF
--- a/tapiriik/services/GarminConnect/garminconnect.py
+++ b/tapiriik/services/GarminConnect/garminconnect.py
@@ -191,7 +191,7 @@ class GarminConnectService(ServiceBase):
             # "redirectAfterAccountCreationUrl": "http://connect.garmin.com/post-auth/login",
             # "webhost": "olaxpw-connect00.garmin.com",
             "clientId": "GarminConnect",
-            # "gauthHost": "https://sso.garmin.com/sso",
+            "gauthHost": "https://sso.garmin.com/sso",
             # "rememberMeShown": "true",
             # "rememberMeChecked": "false",
             "consumeServiceTicket": "false",


### PR DESCRIPTION
Due to a change in Garmin SSO login, gauthHost parameter is now required.
Thanks to @jlouder and @brucekaskel
Fix #278 