### PR TITLE
RunKeeper character encoding fix

### DIFF
--- a/tapiriik/services/RunKeeper/runkeeper.py
+++ b/tapiriik/services/RunKeeper/runkeeper.py
@@ -71,7 +71,8 @@ class RunKeeperService(ServiceBase):
         pass
 
     def _apiHeaders(self, serviceRecord):
-        return {"Authorization": "Bearer " + serviceRecord.Authorization["Token"]}
+        return {"Authorization": "Bearer " + serviceRecord.Authorization["Token"],
+                "Accept-Charset": "UTF-8"}
 
     def _getAPIUris(self, serviceRecord):
         if hasattr(self, "_uris"):  # cache these for the life of the batch job at least? hope so


### PR DESCRIPTION
The default character encoding of RunKeeper API response is `ISO-8859-1` which does not support non-latin characters. We can change the encoding to utf-8 by adding `Accept-Charset` header in requests (https://groups.google.com/d/msg/HealthGraph/RavTaF7LBvk/8qlhMaloU0MJ).

This fixes #85.

--------
Test code:

```python
from tapiriik.database import *
from tapiriik.services import *

serviceRecord = ServiceRecord(db.connections.find_one({"Service": "runkeeper"}))

activities = RunKeeper.DownloadActivityList(serviceRecord)[0]
activity = RunKeeper.DownloadActivity(serviceRecord, activities[0])

print(activity.Notes)
```

Before:
```
RunKeeper UTF-8 Test - ????????? Language Learning and Teaching ???????? ? ???????? ??????????? ?????? Tere Daaheng Aneng Karimah ????????? Enseñanza y estudio de idiomas ????????? ? ??????????? ?? ????? ????? ??????? ???? ???????? ?? ???????? 'læ??wid? 'l?r:ni? ænd 'ti:t?i? Lus kawm thaib qhia Ngôn Ng?, S? h?c, ‭‫????? ????? ?? ????? L'enseignement et l'étude des langues ????? ???? Nauka j?zyków obcych ???????? ???????? ??? ?????????? ‭‫????? ? ??????? ???? Sprachlernen und -lehren ‭‫???? ?????? ??????? ???????????????
```

After:
```
RunKeeper UTF-8 Test - 外国語の学習と教授 Language Learning and Teaching Изучение и обучение иностранных языков Tere Daaheng Aneng Karimah 語文教學・语文教学 Enseñanza y estudio de idiomas Изучаване и Преподаване на Чужди Езици ქართული ენის შესწავლა და სწავლება 'læŋɡwidʒ 'lɘr:niŋ ænd 'ti:tʃiŋ Lus kawm thaib qhia Ngôn Ngữ, Sự học, ‭‫ללמוד וללמד את השֵפה L'enseignement et l'étude des langues 말배우기와 가르치기 Nauka języków obcych Γλωσσική Εκμὰθηση και Διδασκαλία ‭‫ﺗﺪﺭﯾﺲ ﻭ ﯾﺎﺩﮔﯿﺮﯼ ﺯﺑﺎﻥ Sprachlernen und -lehren ‭‫ﺗﻌﻠﻢ ﻭﺗﺪﺭﻳﺲ ﺍﻟﻌﺮﺑﻴﺔ เรียนและสอนภาษา
```