### PR TITLE
fix endomondo activities that don't roundtrip

### DIFF
--- a/tapiriik/services/Endomondo/endomondo.py
+++ b/tapiriik/services/Endomondo/endomondo.py
@@ -297,15 +297,15 @@ class EndomondoService(ServiceBase):
         csp.update(SECRET_KEY.encode("utf-8"))
         return "tap-" + csp.hexdigest()
     
-    def _shouldUseOriginalSport(activity):
+    def _shouldUseOriginalSport(self, activity):
         # This is an activity type that doesn't round trip
-        return (activity.Type in _activitiesThatDontRoundTrip and 
+        return (activity.Type in self._activitiesThatDontRoundTrip and 
         # We have the original sport
         "Sport" in activity.ServiceData and 
         # We know what this sport is
-        activity.ServiceData["Sport"] in _activityMappings and 
+        activity.ServiceData["Sport"] in self._activityMappings and 
         # The type didn't change (if we changed from Walking to Cycling, we'd want to let the new value through)
-        activity.Type == _activityMappings[activity.ServiceData["Sport"]])
+        activity.Type == self._activityMappings[activity.ServiceData["Sport"]])
 
     def UploadActivity(self, serviceRecord, activity):
         session = self._oauthSession(serviceRecord)

--- a/tapiriik/services/Endomondo/endomondo.py
+++ b/tapiriik/services/Endomondo/endomondo.py
@@ -297,15 +297,15 @@ class EndomondoService(ServiceBase):
         csp.update(SECRET_KEY.encode("utf-8"))
         return "tap-" + csp.hexdigest()
     
-    def _getSport(activity):
+    def _getSport(self, activity):
         # This is an activity type that doesn't round trip
-        if (activity.Type in _activitiesThatDontRoundTrip and 
+        if (activity.Type in self._activitiesThatDontRoundTrip and 
         # We have the original sport
         "Sport" in activity.ServiceData and 
         # We know what this sport is
-        activity.ServiceData["Sport"] in _activityMappings and 
+        activity.ServiceData["Sport"] in self._activityMappings and 
         # The type didn't change (if we changed from Walking to Cycling, we'd want to let the new value through)
-        activity.Type == _activityMappings[activity.ServiceData["Sport"]])
+        activity.Type == self._activityMappings[activity.ServiceData["Sport"]])
             return activity.ServiceData["Sport"]
         else
             return [k for k,v in self._reverseActivityMappings.items() if v == activity.Type][0]

--- a/tapiriik/services/Endomondo/endomondo.py
+++ b/tapiriik/services/Endomondo/endomondo.py
@@ -305,9 +305,9 @@ class EndomondoService(ServiceBase):
         # We know what this sport is
         activity.ServiceData["Sport"] in self._activityMappings and 
         # The type didn't change (if we changed from Walking to Cycling, we'd want to let the new value through)
-        activity.Type == self._activityMappings[activity.ServiceData["Sport"]])
+        activity.Type == self._activityMappings[activity.ServiceData["Sport"]]):
             return activity.ServiceData["Sport"]
-        else
+        else:
             return [k for k,v in self._reverseActivityMappings.items() if v == activity.Type][0]
 
     def UploadActivity(self, serviceRecord, activity):

--- a/tapiriik/services/Endomondo/endomondo.py
+++ b/tapiriik/services/Endomondo/endomondo.py
@@ -328,7 +328,7 @@ class EndomondoService(ServiceBase):
 
         activity_id = "tap-" + activity.UID + "-" + str(os.getpid())
         
-        if _shouldUseOriginalSport(activity)
+        if self._shouldUseOriginalSport(activity)
             # it's something that doesn't round trip, use the original 
             sport = activity.ServiceData["Sport"]
         else


### PR DESCRIPTION
map endomondo activities to their original sport if they don't round trip correctly

should fix https://github.com/cpfair/tapiriik/issues/177 and probably https://github.com/cpfair/tapiriik/issues/195 

Say you had a workout in Endomondo that was "cycling transportation" and got sync'd as ActivityType.Cycling.
When Tapiriik updates that activity back to Endomondo, it'll get uploaded as "cycling sport" (since Tapiriik can only map to that) and duplicated.
This change stores the original sport type string with the activity, then (if needed) uploads with the original string.

Will want to double check the syntax and test this quite a bit.  I haven't written python in years!  Also, I don't have the test environment on my machine.

Thanks!