### PR TITLE
Add Yoga activity type

### DIFF
--- a/tapiriik/services/RunKeeper/runkeeper.py
+++ b/tapiriik/services/RunKeeper/runkeeper.py
@@ -37,6 +37,7 @@ class RunKeeperService(ServiceBase):
                          "Rowing": ActivityType.Rowing,
                          "Elliptical": ActivityType.Elliptical,
                          "Strength Training": ActivityType.StrengthTraining,
+                         "Yoga": ActivityType.Yoga,
                          "Other": ActivityType.Other}
     SupportedActivities = list(_activityMappings.values())
 

--- a/tapiriik/services/Strava/strava.py
+++ b/tapiriik/services/Strava/strava.py
@@ -52,6 +52,7 @@ class StravaService(ServiceBase):
         ActivityType.Elliptical: "Elliptical",
         ActivityType.RollerSkiing: "RollerSki",
         ActivityType.StrengthTraining: "WeightTraining",
+        ActivityType.Yoga: "Yoga",
     }
 
     # For mapping Strava->common
@@ -78,6 +79,7 @@ class StravaService(ServiceBase):
         "Elliptical": ActivityType.Elliptical,
         "RollerSki": ActivityType.RollerSkiing,
         "WeightTraining": ActivityType.StrengthTraining,
+        "Yoga": ActivityType.Yoga,
     }
 
     SupportedActivities = list(_activityTypeMappings.keys())

--- a/tapiriik/services/interchange.py
+++ b/tapiriik/services/interchange.py
@@ -23,6 +23,7 @@ class ActivityType:  # taken from RK API docs. The text values have no meaning e
     Climbing = "Climbing"
     RollerSkiing = "RollerSkiing"
     StrengthTraining = "StrengthTraining"
+    Yoga = "Yoga"
     Other = "Other"
 
     def List():


### PR DESCRIPTION
Fixes #223

Works for Strava and Runkeeper.

Garmin doesn't support Yoga as an activity type so we do not upload and it says "Garmin Connect does not support this type of activity." on the activities page.

Don't use any other services so haven't tested them.