### PR TITLE
Strava: BackcountrySki mapping

### DIFF
--- a/tapiriik/services/Strava/strava.py
+++ b/tapiriik/services/Strava/strava.py
@@ -66,7 +66,7 @@ class StravaService(ServiceBase):
         "AlpineSki": ActivityType.DownhillSkiing,
         "CrossCountrySkiing": ActivityType.CrossCountrySkiing,
         "NordicSki": ActivityType.CrossCountrySkiing,
-        "BackcountrySki": ActivityType.DownhillSkiing,
+        "BackcountrySki": ActivityType.CrossCountrySkiing,
         "Snowboard": ActivityType.Snowboarding,
         "Swim": ActivityType.Swimming,
         "IceSkate": ActivityType.Skating,


### PR DESCRIPTION
Mapping BackcountrySki to CrossCountrySkiing, instead of DownhillSkiing.