### PR TITLE
Sync StrengthTraining activities with Dropbox

### DIFF
--- a/tapiriik/services/Dropbox/dropbox.py
+++ b/tapiriik/services/Dropbox/dropbox.py
@@ -40,6 +40,7 @@ class DropboxService(ServiceBase):
         ActivityType.Rowing: "row",
         ActivityType.Elliptical: "elliptical",
         ActivityType.RollerSkiing: "rollerskiing",
+        ActivityType.StrengthTraining: "strengthtraining",
         ActivityType.Other: "(other|unknown)"
     }
     ConfigurationDefaults = {"SyncRoot": "/", "UploadUntagged": False, "Format":"tcx", "Filename":"%Y-%m-%d_#NAME_#TYPE"}


### PR DESCRIPTION
My new fancy garmin watch has a strength training mode. Saving me the massive inconvenience of manually entering the duration. This means they are now non-stationary activities, so could now sync to dropbox. I'm not sure this is particularly useful (maybe the heart rate data is?), but why not!?