### PR TITLE
Ignore "runtastic" in filename for Dropbox sync

### DIFF
--- a/tapiriik/services/Dropbox/dropbox.py
+++ b/tapiriik/services/Dropbox/dropbox.py
@@ -28,7 +28,7 @@ class DropboxService(ServiceBase):
     ReceivesStationaryActivities = False
 
     ActivityTaggingTable = {  # earlier items have precedence over
-        ActivityType.Running: "run",
+        ActivityType.Running: "run(?!tastic)",
         ActivityType.MountainBiking: "m(oun)?t(ai)?n\s*bik(e|ing)",
         ActivityType.Cycling: "(cycl(e|ing)|bik(e|ing))",
         ActivityType.Walking: "walk",
@@ -123,6 +123,7 @@ class DropboxService(ServiceBase):
     def _tagActivity(self, text):
         for act, pattern in self.ActivityTaggingTable.items():
             if re.search(pattern, text, re.IGNORECASE):
+                logger.debug("File %s tagged as %s" % (text, act))
                 return act
         return None
 


### PR DESCRIPTION
Files exported from runtastic have `runtastic_NNNNNNN_NNNN_Running`, `runtastic_NNNNNNN_NNNN_Cycling` etc. names. (Where N are some digits)
It causes that all activities are matched as Running.
This change ignores `runtastic` in filename when activity type is matched and activities are matched correctly

Example debug output:
```
File /runtastic_20170701_1114_cycling.gpx tagged as Cycling
File /runtastic_20170701_1115_running.gpx tagged as Running
```