### PR TITLE
For TrainAsONE exhaustive fetch, use larger list pageSize

### DIFF
--- a/tapiriik/services/TrainAsONE/trainasone.py
+++ b/tapiriik/services/TrainAsONE/trainasone.py
@@ -75,7 +75,10 @@ class TrainAsONEService(ServiceBase):
     def DownloadActivityList(self, serviceRecord, exhaustive=False):
         allItems = []
 
-        pageUri = TRAINASONE_SERVER_URL + "/api/sync/activities"
+        if exhaustive:
+            pageUri = TRAINASONE_SERVER_URL + "/api/sync/activities?pageSize=200"
+        else:
+            pageUri = TRAINASONE_SERVER_URL + "/api/sync/activities"
 
         while True:
             response = requests.get(pageUri,  headers=self._apiHeaders(serviceRecord.Authorization))


### PR DESCRIPTION
this should hopefully reduce the number of calls to enumerate the list of activities, but switching from the default 10 to 200 entries per call

Thanks