### PR TITLE
Add docker. Configure tapiriik faster :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 local_settings.py
 *.sublime-workspace
 private/
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:16.04
+
+COPY . /tapiriik
+
+RUN apt-get update \
+    && apt-get install -y \
+        git \
+        python3-pip \
+        libxslt-dev \
+        libxml2-dev \
+        python3-lxml \
+        python3-crypto \
+    && cd /tapiriik \
+    && pip3 install -r requirements.txt \
+    && cp tapiriik/local_settings.py.example tapiriik/local_settings.py \
+    && python3 credentialstore_keygen.py >> tapiriik/local_settings.py
+
+WORKDIR /tapiriik
+
+RUN echo "" >> tapiriik/local_settings.py \
+    && echo 'MONGO_HOST = "mongodb"' >> tapiriik/local_settings.py \
+    && echo 'REDIS_HOST = "redis"' >> tapiriik/local_settings.py \
+    && echo 'RABBITMQ_BROKER_URL = "amqp://guest@rabbitmq//"' >> tapiriik/local_settings.py \
+    && echo -n "\n\nHow fun is that?\n\n\n"
+
+ENTRYPOINT ["python3","/tapiriik/manage.py","runserver"]
+CMD ["0.0.0.0:8000"]
+
+EXPOSE 8000

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,5 @@
+version: '2'
+services:
+    tapiriik:
+        volumes:
+            - ./:/tapiriik/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '2'
+services:
+    tapiriik:
+        image: tapiriik
+        build:
+            context: .
+            dockerfile: Dockerfile
+        command: ["0.0.0.0:8000"]
+        ports:
+            - "8000:8000"
+        depends_on:
+            - redis
+            - rabbitmq
+            - mongodb
+    redis:
+        image: redis:latest
+    rabbitmq:
+        image: rabbitmq:latest
+    mongodb:
+        image: mongo:latest


### PR DESCRIPTION
In order to start tapiriik faster for newcomers, there is a new docker-way. Just:
```
git clone https://github.com/cpfair/tapiriik.git
cd tapiriik 
cp docker-compose.override.yml{.example,} # if you want your local changes to apply immediately without rebuilding the image. 
docker-compose up # add "d" (without ") if you want to daemonize
```

And it's running on http://localhost:8000 

ps: The databases' states are not saved. If you remove the docker containers, 'persistent' data will be lost.