### PR TITLE
Add Rock Climbing activity type in Strava sync

### DIFF
--- a/tapiriik/services/Strava/strava.py
+++ b/tapiriik/services/Strava/strava.py
@@ -52,6 +52,7 @@ class StravaService(ServiceBase):
         ActivityType.Elliptical: "Elliptical",
         ActivityType.RollerSkiing: "RollerSki",
         ActivityType.StrengthTraining: "WeightTraining",
+        ActivityType.Climbing: "RockClimbing",
     }
 
     # For mapping Strava->common
@@ -78,6 +79,7 @@ class StravaService(ServiceBase):
         "Elliptical": ActivityType.Elliptical,
         "RollerSki": ActivityType.RollerSkiing,
         "WeightTraining": ActivityType.StrengthTraining,
+        "RockClimbing" : ActivityType.Climbing,
     }
 
     SupportedActivities = list(_activityTypeMappings.keys())


### PR DESCRIPTION
Strava has a rock climbing type activity (see [documentation](https://developers.strava.com/playground/#/Activities/updateActivityById)), would it be possible to add it?