### PR TITLE
Add source file to Activity interchange object

### DIFF
--- a/tapiriik/services/interchange.py
+++ b/tapiriik/services/interchange.py
@@ -58,7 +58,7 @@ class ActivityType:  # taken from RK API docs. The text values have no meaning e
 
 
 class Activity:
-    def __init__(self, startTime=None, endTime=None, actType=ActivityType.Other, distance=None, name=None, notes=None, tz=None, lapList=None, private=False, fallbackTz=None, stationary=None, gps=None, device=None):
+    def __init__(self, startTime=None, endTime=None, actType=ActivityType.Other, distance=None, name=None, notes=None, tz=None, lapList=None, private=False, fallbackTz=None, stationary=None, gps=None, device=None, sourceFile=None):
         self.StartTime = startTime
         self.EndTime = endTime
         self.Type = actType
@@ -73,6 +73,7 @@ class Activity:
         self.GPS = gps
         self.PrerenderedFormats = {}
         self.Device = device
+        self.SourceFile = sourceFile
 
     def CalculateUID(self):
         if not self.StartTime:
@@ -355,6 +356,18 @@ class Activity:
     def __le__(self, other):
         return not self.__gt__(other)
 
+class ActivityFileType:
+    FIT = ".fit"
+    TCX = ".tcx"
+    GPX = ".gpx"
+
+class SourceFile:
+    def __init__(self, textContent, contentType):
+        self._textContent = textContent
+        self._contentType = contentType
+
+    def getContent(self, contentType):        
+        return self._textContent if self._contentType is contentType else None
 
 class UploadedActivity (Activity):
     pass  # will contain list of which service instances contain this activity - not really merited


### PR DESCRIPTION
Now it is able to write raw activity source content to interchange object.
Will be useful for services which use files for their api. like aerobia.com
I also decided to introduce this because TCXIO seems not functioning correctly and chain activity.tcx - tcx.Parse - activity - tcx.Dump - will produce different file out most of the time. Need to cover IO modules with such tests and fix later. Than may be we will don't ever need this code.