### PR TITLE
Smashrun: Fetch activities without pagination when doing exhaustive sync

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ django-pipeline==1.5.1
 requests_oauthlib==0.4.0
 redis
 django-ipware
-smashrun-client>=0.2.0
+smashrun-client>=0.6.0
 beautifulsoup4

--- a/tapiriik/services/Smashrun/smashrun.py
+++ b/tapiriik/services/Smashrun/smashrun.py
@@ -19,6 +19,10 @@ from tapiriik.services.sessioncache import SessionCache
 
 logger = logging.getLogger(__name__)
 
+# The number of activities to fetch per 'page' when iterating through the
+# Smashrun API.
+PAGE_COUNT = 20
+
 
 def handleExpiredToken(f):
     """Handle token expiry during execution of `f`.
@@ -135,12 +139,9 @@ class SmashrunService(ServiceBase):
     @handleExpiredToken
     def _getActivities(self, serviceRecord, exhaustive=False):
         client = self._getClient(serviceRec=serviceRecord)
-        activities = []
-        for i, act in enumerate(client.get_activities()):
-            if not exhaustive and i > 20:
-                return activities
-            activities.append(act)
-        return activities
+        return list(client.get_activities(
+                        count=None if exhaustive else PAGE_COUNT,
+                        limit=None if exhaustive else PAGE_COUNT))
 
     @handleExpiredToken
     def _getActivity(self, serviceRecord, activity):


### PR DESCRIPTION
@chrislukic suggested that we disable pagination when performing an
exhaustive sync to help reduce the load on his servers.

While we're at it, we can also take advantage of the new(-ish) `limit`
kwarg in `SmashrunClient.get_activities` to fix an off-by-one error 
where we always fetched 30 activities during the non-exhaustive 
sync when we only intended to fetch 20.

Fixes #448