### PR TITLE
Improve error handling when deauthorizing

### DIFF
--- a/tapiriik/web/static/js/tapiriik.js
+++ b/tapiriik/web/static/js/tapiriik.js
@@ -251,7 +251,13 @@ tapiriik.OpenDeauthDialog = function(svcId){
 					window.location.reload();
 				},
 				error: function(data){
-					alert("Error in disconnection: " + $.parseJSON(data.responseText).error+"\n Please contact me ASAP");
+					var errorMessage;
+					try {
+						errorMessage = $.parseJSON(data.responseText).error
+					} catch (e) {
+						errorMessage = data.responseText;
+					}
+					alert("Error in disconnection: " + errorMessage+"\n Please contact me ASAP");
 					tapiriik.DeauthPending = undefined;
 					$("#disconnect", form).removeClass("disabled");
 				}});


### PR DESCRIPTION
As mentioned in #438, if there is a server error when deauthorizing a service it might fail silently. This is because we assume that the response to the browser is JSON encoded and if not we fail with a SyntaxError.

This commit simply adds a try-catch around the JSON parsing and uses the complete response text as the message if the parsing fails.