### PR TITLE
Garmin sparse data fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - "3.3"
+    - "3.6"
 services:
     - mongodb
     - redis-server

--- a/tapiriik/services/GarminConnect/garminconnect.py
+++ b/tapiriik/services/GarminConnect/garminconnect.py
@@ -453,7 +453,6 @@ class GarminConnectService(ServiceBase):
         try:
             tcx_data = res.text
             activity = TCXIO.Parse(tcx_data.encode('utf-8'), activity)
-            activity.SourceFile = SourceFile(tcx_data, ActivityFileType.TCX)
         except ValueError:
             raise APIException("Activity data parse error for %s: %s" % (res.status_code, res.text))
 

--- a/tapiriik/services/tcx.py
+++ b/tapiriik/services/tcx.py
@@ -229,10 +229,15 @@ class TCXIO:
             sum_stats.update(act.Stats)
             act.Stats = sum_stats
 
+        act.PrerenderedFormats["tcx"] = tcxData
+
         act.CalculateUID()
         return act
     
     def Dump(activity, activityType=None):
+
+        if "tcx" in activity.PrerenderedFormats:
+            return activity.PrerenderedFormats["tcx"]
 
         root = etree.Element("TrainingCenterDatabase", nsmap=TCXIO.Namespaces)
         activities = etree.SubElement(root, "Activities")
@@ -384,6 +389,5 @@ class TCXIO:
                 etree.SubElement(xver, "VersionMinor").text = str(activity.Device.VersionMinor) if activity.Device.VersionMinor else "0"
                 etree.SubElement(xver, "BuildMajor").text = "0"
                 etree.SubElement(xver, "BuildMinor").text = "0"
-
 
         return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="UTF-8").decode("UTF-8")


### PR DESCRIPTION
1. https://connect.garmin.com/modern/proxy/activity-service/activity/###/details API endpoint is used bu GC for UI track rendering so data is very sparse. Download garmin file as full tcx + optimise for Dropbox.
2. Fix travis python version to make unit tests work again.