### PR TITLE
Upgrade vagrant config to Ubuntu 18.04 and fix mongo 3 incompatibility

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "bento/ubuntu-14.04"
+  config.vm.box = "bento/ubuntu-18.04"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,24 +1,20 @@
 #!/usr/bin/env bash
 
 # Install system requirements
-
-# mongodb multipolygon geojson support needs at least mongodb 2.6. trusty has 2.4 by default
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-
-
 sudo apt-get update
-sudo apt-get install -y python3-pip libxml2-dev libxslt-dev zlib1g-dev git redis-server rabbitmq-server mongodb-org=2.6.9
+sudo apt-get install -y python3-pip libxml2-dev libxslt-dev zlib1g-dev git redis-server rabbitmq-server mongodb-server
 
-# Fix pip
+# upgrade pip
 pip3 install --upgrade pip
+
+# Fix the default python and pip instance
+update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
+update-alternatives --install /usr/bin/python python /usr/bin/python3.6 2
+update-alternatives --install /usr/bin/pip pip /usr/local/bin/pip3 1
+update-alternatives --force --install /usr/bin/pip3 pip3 /usr/local/bin/pip3 1
 
 # Install app requirements
 pip install --upgrade -r /vagrant/requirements.txt
-
-# Fix the default python instance
-update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
-update-alternatives --install /usr/bin/python python /usr/bin/python3.4 2
 
 # Put in a default local_settings.py (if one doesn't exist)
 if [ ! -f /vagrant/tapiriik/local_settings.py ]; then

--- a/tapiriik/services/Dropbox/dropbox.py
+++ b/tapiriik/services/Dropbox/dropbox.py
@@ -178,7 +178,10 @@ class DropboxService(ServiceBase):
                 cachedb.dropbox_cache.save(cache)
             else:
                 insert_result = cachedb.dropbox_cache.insert(cache)
-                cache["_id"] = insert_result.inserted_id
+                if hasattr(insert_result, 'inserted_id'):
+                    cache["_id"] = insert_result.inserted_id
+                else:
+                    cache["_id"] = insert_result
 
 
         activities = []


### PR DESCRIPTION
This should fix the ability to use vagrant on a fresh checkout.  It upgrades to Bionic (18.04).

Travis is showing this as not working, but that's due to the existing problem there.  I tried to also update `.travis.yml` config (like #502), but I couldn't get it working - something about the newer ubuntus in travis having an IPV6 `localhost` record (eg, https://travis-ci.org/mduggan/tapiriik/builds/600559948)

(fixes #491)