### PR TITLE
Allow non-gps activities to sync to Endomondo

### DIFF
--- a/tapiriik/services/Endomondo/endomondo.py
+++ b/tapiriik/services/Endomondo/endomondo.py
@@ -93,7 +93,7 @@ class EndomondoService(ServiceBase):
 
     SupportedActivities = list(_activityMappings.values())
 
-    ReceivesNonGPSActivitiesWithOtherSensorData = False
+    ReceivesNonGPSActivitiesWithOtherSensorData = True
 
     def WebInit(self):
         self.UserAuthorizationURL = reverse("oauth_redirect", kwargs={"service": "endomondo"})


### PR DESCRIPTION
It used to be true that Endomondo was dependent on GPS data but this was a long time ago.

Since Endomondo won't give new API KEYs, I obviously can't _actually_ test the Tapiriik version of this process myself (unless you share the API keys with me) but I've tested using the non-official API (eg. https://github.com/kanekotic/endomondo-unofficial-api) and simply having the Lat/Long fields set to empty strings and including all the rest of the sensor data works just fine. Endomondo reads the trackpoints and saves all the rest of the sensors info (at least for cadence/speed/hr which are the ones exposed using that alternative "api").